### PR TITLE
fix: FileLock re-entrancy and merge auto-extracted triples (1.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 All notable changes to EpochDB will be documented in this file.
 
+## [1.8.1] - 2026-07-26
+### Fixed
+- **FileLock Re-entrancy**: Fixed `FileLock.acquire()` to handle current-process re-entry when `existing_pid == os.getpid()`, preventing false-positive "Database is locked by another process" exceptions.
+### Changed
+- **Merge Auto-Extract With Provided Triples**: When `auto_extract=True`, `remember` / `remember_batch` now merge discovered entity co-occurrence triples with any caller-supplied structural triples instead of skipping extraction.
+
 ## [1.8.0] - 2026-07-25
 ### Changed
 - **Pairwise Entity Relationship Triples**: Updated `LocalFactExtractor` and fallback memory entity extraction to generate pairwise co-occurrence relationship triples `(entity1, "co_occurs_with", entity2)` between distinct entities, eliminating isolated single-entity self-loops (`(entity, "mentions", entity)`).

--- a/epochdb/api/db.py
+++ b/epochdb/api/db.py
@@ -33,7 +33,7 @@ class Memory:
 def _build_pairwise_triples(extracted: list) -> list:
     seen = set()
     entities = []
-    for e in extracted:
+    for e in extracted or []:
         s = str(e)
         if s and s not in seen:
             seen.add(s)
@@ -48,6 +48,41 @@ def _build_pairwise_triples(extracted: list) -> list:
     elif len(entities) == 1:
         return [(entities[0], "mentions", entities[0])]
     return []
+
+
+def _merge_triples(*groups) -> list:
+    """Deduplicate (subject, predicate, object) triples across groups."""
+    merged = []
+    seen = set()
+    for group in groups:
+        for t in group or []:
+            if isinstance(t, (list, tuple)) and len(t) >= 3:
+                key = (str(t[0]), str(t[1]), str(t[2]))
+            else:
+                continue
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(key)
+    return merged
+
+
+def _resolve_ingest_triples(engine, text: str, triples, metadata: dict) -> list:
+    """Combine caller-provided triples with auto-extracted entity links."""
+    provided = triples
+    if provided is None:
+        provided = (metadata or {}).get("triples")
+    provided = list(provided or [])
+
+    discovered = []
+    if getattr(engine, "auto_extract", False):
+        from epochdb.core.fact_extractor import FactExtractor
+        extractor = FactExtractor(engine, engine.extraction_model)
+        discovered = extractor.extract(text) or []
+    elif not provided:
+        discovered = _build_pairwise_triples(engine.extract_entities(text))
+
+    return _merge_triples(provided, discovered)
 
 
 class Entity(str):
@@ -153,16 +188,8 @@ class EpochDB(EngineEpochDB):
             else:
                 embedding = np.zeros(self.dim, dtype=np.float32)
 
-            if triples is None:
-                triples = metadata.get("triples")
-            
-            if not triples and self.auto_extract:
-                from epochdb.core.fact_extractor import FactExtractor
-                extractor = FactExtractor(self, self.extraction_model)
-                triples = extractor.extract(text)
-            elif not triples:
-                extracted = self.extract_entities(text)
-                triples = _build_pairwise_triples(extracted)
+            triples = _resolve_ingest_triples(self, text, triples, metadata)
+            metadata["triples"] = triples
 
             atom_id = self.add_memory(
                 payload=text,
@@ -205,14 +232,9 @@ class EpochDB(EngineEpochDB):
 
             batch_items = []
             for i, (text, metadata) in enumerate(zip(texts, metadatas)):
-                triples = metadata.get("triples") or []
-                if not triples and self.auto_extract:
-                    from epochdb.core.fact_extractor import FactExtractor
-                    extractor = FactExtractor(self, self.extraction_model)
-                    triples = extractor.extract(text)
-                elif not triples:
-                    extracted = self.extract_entities(text)
-                    triples = _build_pairwise_triples(extracted)
+                triples = _resolve_ingest_triples(self, text, None, metadata)
+                metadata = dict(metadata or {})
+                metadata["triples"] = triples
 
                 batch_items.append({
                     "payload": text,

--- a/epochdb/core/transaction.py
+++ b/epochdb/core/transaction.py
@@ -111,6 +111,10 @@ class FileLock:
                 # Unreadable lock file → treat as stale.
                 existing_pid = None
 
+            if existing_pid == pid:
+                # Lock is already held by current process
+                return
+
             if existing_pid and _pid_is_alive(existing_pid):
                 raise RuntimeError(
                     f"Database is locked by another process (PID {existing_pid}): "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "epochdb"
-version = "1.8.0"
+version = "1.8.1"
 description = "An agentic memory engine designed for lossless, tiered verbatim storage and multi-hop retrieval."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Prevent false "Database is locked" errors when the same process re-enters FileLock, and merge AUTO_EXTRACT entity co-occurrence triples with caller-supplied structural triples so rebuild/index flows discover new links.