### PR TITLE
fix: exclude predicates from LocalFactExtractor co-occurrence (1.8.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 All notable changes to EpochDB will be documented in this file.
 
+## [1.8.2] - 2026-07-26
+### Fixed
+- **Predicate pollution in LocalFactExtractor**: Entity co-occurrence triples no longer treat known predicates (e.g. `document_type`, `part_of`) as graph nodes when `extract_entities` Pass-2 matches them in text.
+
 ## [1.8.1] - 2026-07-26
 ### Fixed
 - **FileLock Re-entrancy**: Fixed `FileLock.acquire()` to handle current-process re-entry when `existing_pid == os.getpid()`, preventing false-positive "Database is locked by another process" exceptions.

--- a/epochdb/core/fact_extractor.py
+++ b/epochdb/core/fact_extractor.py
@@ -83,7 +83,13 @@ class LocalFactExtractor:
 
         seen = set()
         entities = []
+        predicates = set()
+        if self.engine is not None:
+            predicates = {str(p) for p in getattr(self.engine, "predicates", set()) or set()}
         for e in raw_entities:
+            # Predicates matched by extract_entities Pass-2 must not become graph nodes.
+            if e in predicates or e.lower().replace(" ", "_") in {p.lower() for p in predicates}:
+                continue
             if e not in seen:
                 seen.add(e)
                 entities.append(e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "epochdb"
-version = "1.8.1"
+version = "1.8.2"
 description = "An agentic memory engine designed for lossless, tiered verbatim storage and multi-hop retrieval."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Prevent document_type/part_of and other known predicates from becoming entity graph nodes when auto-extract builds co_occurs_with triples.